### PR TITLE
Fix some login error on android

### DIFF
--- a/android/src/main/java/com/xmartlabs/lineloginmanager/LineLogin.java
+++ b/android/src/main/java/com/xmartlabs/lineloginmanager/LineLogin.java
@@ -33,22 +33,24 @@ public class LineLogin extends ReactContextBaseJavaModule {
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
             super.onActivityResult(activity, requestCode, resultCode, data);
             if (currentPromise != null) {
+                final Promise promise = currentPromise;
+                currentPromise = null;
                 if (requestCode != REQUEST_CODE) {
-                    currentPromise.reject(ERROR, "Unsupported request");
+                    promise.reject(ERROR, "Unsupported request");
                     return;
                 }
                 loginResult = LineLoginApi.getLoginResultFromIntent(data);
                 switch (loginResult.getResponseCode()) {
                     case SUCCESS:
-                        currentPromise.resolve(parseLoginResult(loginResult));
+                        promise.resolve(parseLoginResult(loginResult));
                         break;
                     case CANCEL:
                         loginResult = null;
-                        currentPromise.reject(ERROR, "Line login canceled by user");
+                        promise.reject(ERROR, "Line login canceled by user");
                         break;
                     default:
                         loginResult = null;
-                        currentPromise.reject(ERROR, loginResult.getErrorData().toString());
+                        promise.reject(ERROR, loginResult.getErrorData().toString());
                         break;
                 }
             }
@@ -143,10 +145,14 @@ public class LineLogin extends ReactContextBaseJavaModule {
 
         @Override
         protected void onPostExecute(LineApiResponse lineApiResponse) {
-            if (lineApiResponse.isSuccess()) {
-                currentPromise.resolve(new Object());
-            } else {
-                currentPromise.reject(ERROR, lineApiResponse.getErrorData().toString());
+            if (currentPromise != null) {
+                final Promise promise = currentPromise;
+                currentPromise = null;
+                if (lineApiResponse.isSuccess()) {
+                    promise.resolve(null);
+                } else {
+                    promise.reject(ERROR, lineApiResponse.getErrorData().toString());
+                }
             }
         }
     }
@@ -157,10 +163,14 @@ public class LineLogin extends ReactContextBaseJavaModule {
         }
 
         protected void onPostExecute(LineApiResponse<LineProfile> lineApiResponse) {
-            if (lineApiResponse.isSuccess()) {
-                currentPromise.resolve(parseProfile(lineApiResponse.getResponseData()));
-            } else {
-                currentPromise.reject(ERROR, lineApiResponse.getErrorData().toString());
+            if (currentPromise != null) {
+                final Promise promise = currentPromise;
+                currentPromise = null;
+                if (lineApiResponse.isSuccess()) {
+                    promise.resolve(parseProfile(lineApiResponse.getResponseData()));
+                } else {
+                    promise.reject(ERROR, lineApiResponse.getErrorData().toString());
+                }
             }
         }
     }
@@ -172,10 +182,14 @@ public class LineLogin extends ReactContextBaseJavaModule {
 
         @Override
         protected void onPostExecute(LineApiResponse<LineAccessToken> lineApiResponse) {
-            if (lineApiResponse.isSuccess()) {
-                currentPromise.resolve(parseAccessToken(lineApiResponse.getResponseData()));
-            } else {
-                currentPromise.reject(ERROR, lineApiResponse.getErrorData().toString());
+            if (currentPromise != null) {
+                final Promise promise = currentPromise;
+                currentPromise = null;
+                if (lineApiResponse.isSuccess()) {
+                    promise.resolve(parseAccessToken(lineApiResponse.getResponseData()));
+                } else {
+                    promise.reject(ERROR, lineApiResponse.getErrorData().toString());
+                }
             }
         }
     }

--- a/android/src/main/java/com/xmartlabs/lineloginmanager/LineLogin.java
+++ b/android/src/main/java/com/xmartlabs/lineloginmanager/LineLogin.java
@@ -27,7 +27,6 @@ public class LineLogin extends ReactContextBaseJavaModule {
 
     private LineApiClient lineApiClient;
     private Promise currentPromise;
-    private LineLoginResult loginResult;
     private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
@@ -39,17 +38,18 @@ public class LineLogin extends ReactContextBaseJavaModule {
                     promise.reject(ERROR, "Unsupported request");
                     return;
                 }
-                loginResult = LineLoginApi.getLoginResultFromIntent(data);
+                final LineLoginResult loginResult = LineLoginApi.getLoginResultFromIntent(data);
                 switch (loginResult.getResponseCode()) {
                     case SUCCESS:
                         promise.resolve(parseLoginResult(loginResult));
                         break;
                     case CANCEL:
-                        loginResult = null;
                         promise.reject(ERROR, "Line login canceled by user");
                         break;
+                    case AUTHENTICATION_AGENT_ERROR:
+                        promise.reject(ERROR, "The user has denied the approval");
+                        break;
                     default:
-                        loginResult = null;
                         promise.reject(ERROR, loginResult.getErrorData().toString());
                         break;
                 }


### PR DESCRIPTION
## Fixes

- Fix Argument Exception when called logout(). 37469f7
  - `currentPromise.resolve(new Object());` was called when `LineLogin#logout` is succeed. But Argument Exception was thrown.
- Fix Exception calling promise multiple times when called another intent callback after calling logout(). 37469f7
  - When intent callback was listened, promise object was called. But the Promise object was not deleted after logging in, then Exception was thrown by being called multiple times when other intent calls.
- Fix exception when the user denied the approval. e6b422a
  - Result code of `loginResult` when the user denied the approval is `AUTHENTICATION_AGENT_ERROR`. But NullPointerException was throwed because loginResult was set null.

I comfirmed React Native 0.54.4.