### PR TITLE
[PR] Isolate getUserProfile method from login process

### DIFF
--- a/ios/LineLoginManager.m
+++ b/ios/LineLoginManager.m
@@ -97,11 +97,7 @@ RCT_EXPORT_METHOD(getUserProfile:(RCTPromiseResolveBlock)resolve
 {
     LineSDKLogin *shared = [LineSDKLogin sharedInstance];
     
-    if ([shared isAuthorized])
-    {
-        [self getUserProfile:loginResolver
-                    rejecter:loginRejecter];
-    } else if ([shared canLoginWithLineApp])
+    if ([shared canLoginWithLineApp])
     {
         if (permissions && [permissions count] > 0) {
             [shared startLoginWithPermissions:permissions];


### PR DESCRIPTION
#### ISSUE: #21 

We must isolate `getUserProfile` method from login process. It makes this wrapper distract management of stale tokens. I went through about this stale token issue. As I wrote at #21, if we remove this getting user profile job from login process, we can resolve the stale token management issue between v4 and v5. Thank you.