### PR TITLE
Removes channel id from library string resource

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,5 @@
 ## PR Title
 
-
-#### :link: Trello board reference:
-
-- [Title of the card](https://link-to-trello-card)
-
----
-
 #### 🔄 Type of change:
 
 - [ ] ✨Feature/chore

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
     <string name="app_name">RNLine</string>
-    <string name="line_channel_id" translatable="false">1626112874</string>
+    <string name="line_channel_id" translatable="false"></string>
 </resources>


### PR DESCRIPTION
## Removes channel id from library string resource

#### 🔄 Type of change:

- [ ] ✨Feature/chore
- [x] :recycle: Refactor
- [ ] :wrench: Bugfixes

---

#### :pencil2: Description:

Channel specific id was in library's `strings.xml`. This id was removed but the resource was kept due to `R.string` query in `RNLine.kt` `init()`

---