### PR TITLE
Update Line SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         coroutinesAndroidVersion = "1.0.1"
         coroutinesCoreVersion = "1.0.1"
         gsonVersion = "2.8.6"
-        linesdkVersion = "5.1.1"
+        linesdkVersion = "5.5.1"
     }
     repositories {
         google()
@@ -20,7 +20,7 @@ buildscript {
         classpath "com.android.tools.build:gradle:3.5.1"
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.linecorp:linesdk:5.1.1"
+        classpath "com.linecorp:linesdk:5.5.1"
     }
 }
 
@@ -58,7 +58,7 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.linecorp:linesdk:5.1.1"
+    implementation "com.linecorp:linesdk:5.5.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesAndroidVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesCoreVersion"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ ReactNativeLine_kotlinVersion=1.3.50
 ReactNativeLine_compileSdkVersion=28
 ReactNativeLine_buildToolsVersion=28.0.3
 ReactNativeLine_targetSdkVersion=28
-ReactNativeLine_lineSdkVersion=5.1.1
+ReactNativeLine_lineSdkVersion=5.5.1


### PR DESCRIPTION
## PR Title

#### 🔄 Type of change:

- [x] ✨Feature/chore
- [ ] :recycle: Refactor
- [ ] :wrench: Bugfixes

---

#### :pencil2: Description:

Update Android Line SDK to version `5.5.1`.

[**v5.5.1**](https://github.com/line/line-sdk-android/releases/tag/v5.5.1)

Note: Latest version is `5.6.0` but it's breaking change on minSdkVersion from 17 to 19; update targetSdkVersion from 29 to 30.

---

#### :heavy_check_mark:Tasks:

- Update lineSdkVersion in `build.gradle` and `gradle.properties`.
