### PR TITLE
upgrade ios sdk to 5.8.1/android sdk to 5.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,8 @@ First, install the npm package with yarn. _Autolink_ is automatic.
 Inside your `AppDelegate.m`, setup the line sdk by passing the channel id obtained.
 
 1. Add `platform :ios, '10.0'` in `Podfile` line:1
-2. Enable `use_frameworks!` in `Podfile` line:3
-3. Comment the code related to flipper, flipper doesn't support `use_frameworks!` !
-4. Modify your info.plist like it says here [Configuring the Info.plist file](https://developers.line.biz/en/docs/ios-sdk/swift/setting-up-project/#configuring-the-info-plist-file)
-5. Change your `AppDelegate.m` to match the following:
+2. Modify your info.plist like it says here [Configuring the Info.plist file](https://developers.line.biz/en/docs/ios-sdk/swift/setting-up-project/#configuring-the-info-plist-file)
+3. Change your `AppDelegate.m` to match the following:
 
 ```objc
 // AppDelegate.m
@@ -70,7 +68,7 @@ Inside your `AppDelegate.m`, setup the line sdk by passing the channel id obtain
 //
 // Import the Library
 //
-#import "RNLine-Swift.h"
+@import RNLine;
 
 //
 // Setup the plugin using your CHANNEL_ID when the app finishes launching
@@ -137,7 +135,22 @@ Don't forget to add `application` function, as line's instructions indicate.
 ```
 
 3. Add `minSdkVersion = 17` in `android/build.gradle`
-4. In your manifest add `xmlns:tools="http://schemas.android.com/tools"` in your `manifest` tag and also `tools:replace="android:allowBackup"` in your `application` tag
+4. Add LineSDK as a dependency in `android/build.gradle`
+```gradle
+android {
+  // Enable Java 1.8 support.
+  compileOptions { // <- add this block if didn't setup
+      sourceCompatibility JavaVersion.VERSION_1_8
+      targetCompatibility JavaVersion.VERSION_1_8
+  }
+  ...
+  dependencies {
+    ...
+    implementation 'com.linecorp.linesdk:linesdk:5.7.0' // <- add this line
+  }
+}
+```
+5. In your manifest add `xmlns:tools="http://schemas.android.com/tools"` in your `manifest` tag and also `tools:replace="android:allowBackup"` in your `application` tag
 
 ## API
 

--- a/RNLine.podspec
+++ b/RNLine.podspec
@@ -11,11 +11,11 @@ Pod::Spec.new do |s|
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, "10.0"
-  s.swift_version = '5.0'
+  s.swift_version = '5.8.1'
 
   s.source       = { :git => "" }
   s.source_files  = "ios/**/*.{h,m,swift}"
 
   s.dependency 'React'
-  s.dependency 'LineSDKSwift', '~> 5.0'
+  s.dependency 'LineSDKSwift', '~> 5.8.1'
 end

--- a/RNLine.podspec
+++ b/RNLine.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "" }
   s.source_files  = "ios/**/*.{h,m,swift}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'LineSDKSwift', '~> 5.8.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,14 +2,14 @@ buildscript {
     //Buildscript is evaluated before everything else so we can't use getExtOrDefault
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['ReactNativeLine_kotlinVersion']
     ext {
-        buildToolsVersion = "28.0.3"
+        buildToolsVersion = "30.0.2"
         minSdkVersion = 21
         compileSdkVersion = 28
-        targetSdkVersion = 28
+        targetSdkVersion = 30
         coroutinesAndroidVersion = "1.0.1"
         coroutinesCoreVersion = "1.0.1"
         gsonVersion = "2.8.6"
-        linesdkVersion = "5.1.1"
+        linesdkVersion = "5.7.0"
     }
     repositories {
         google()
@@ -20,7 +20,6 @@ buildscript {
         classpath "com.android.tools.build:gradle:3.5.1"
         //noinspection DifferentKotlinGradleVersion
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.linecorp:linesdk:5.1.1"
     }
 }
 
@@ -58,7 +57,7 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.linecorp:linesdk:5.1.1"
+    implementation 'com.linecorp.linesdk:linesdk:5.7.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesAndroidVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesCoreVersion"

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,4 +2,4 @@ ReactNativeLine_kotlinVersion=1.3.50
 ReactNativeLine_compileSdkVersion=28
 ReactNativeLine_buildToolsVersion=28.0.3
 ReactNativeLine_targetSdkVersion=28
-ReactNativeLine_lineSdkVersion=5.1.1
+ReactNativeLine_lineSdkVersion=5.7.0


### PR DESCRIPTION
## upgrade ios sdk to 5.8.1/android sdk to 5.7.0

#### 🔄 Type of change:

- [x] ✨Feature/chore
- [ ] :recycle: Refactor
- [ ] :wrench: Bugfixes

---

#### :pencil2: Description:

The library SK is out of date. There are newer version to upgrade. Besides, 
#### IOS
we don't need `use_frameworks!` if react-native >= 0.63. 
#### Android
the namespace was changed. `com.linecorp:linesdk` -> `com.linecorp.linesdk:linesdk:`

---

#### :pushpin: Notes:

- for anyone who need to use the latest SDK directly, feel free to use our repo 

```
yarn add verybuy/react-native-line#8dcc99d
```

because we don't have publish permission @xmartlabs/react-native-line, so we build the dist and push to our repo.

You can also checkout the commit. https://github.com/VeryBuy/react-native-line/commits/feature/verybuy

---

#### :heavy_check_mark:Tasks:

- we have integrated in our project and it works. 
---
