### PR TITLE
Add stanalone setup channel ID method for multiple channel ID use cases

### DIFF
--- a/android/src/main/java/com/xmartlabs/rnline/RNLine.kt
+++ b/android/src/main/java/com/xmartlabs/rnline/RNLine.kt
@@ -33,17 +33,17 @@ class RNLine(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule
     }
 
 
-    private val lineApiClient: LineApiClient
-    private val channelId: String
+    private var lineApiClient: LineApiClient
+    private var channelId: String
     private var LOGIN_REQUEST_CODE: Int = 0
     private val uiCoroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Main)
+    private val context: Context = reactContext.applicationContext
 
     private var loginResult: Promise? = null
 
     override fun getName() = MODULE_NAME
 
     init {
-        val context: Context = reactContext.applicationContext
         channelId = context.getString(R.string.line_channel_id)
         lineApiClient = LineApiClientBuilder(context, channelId).build()
         reactContext.addActivityEventListener(object : ActivityEventListener {
@@ -52,6 +52,12 @@ class RNLine(reactContext: ReactApplicationContext) : ReactContextBaseJavaModule
             override fun onActivityResult(activity: Activity?, requestCode: Int, resultCode: Int, data: Intent?) =
                     handleActivityResult(requestCode, resultCode, data)
         })
+    }
+
+    @ReactMethod
+    fun configure(args: ReadableMap, promise: Promise) {
+        channelId = if (args.hasKey(ConfigureArguments.CHANNEL_ID.key)) args.getString(ConfigureArguments.CHANNEL_ID.key)!!.toString() else context.getString(R.string.line_channel_id)
+        lineApiClient = LineApiClientBuilder(context, channelId).build()
     }
 
     @ReactMethod

--- a/ios/LineLogin.m
+++ b/ios/LineLogin.m
@@ -34,4 +34,9 @@
                   verifyAccessToken: (RCTPromiseResolveBlock)resolve
                   rejecter: (RCTPromiseRejectBlock)reject
                   )
+  RCT_EXTERN_METHOD(
+                  configure: (NSDictionary *)arguments
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject
+                  )
 @end

--- a/ios/LineLogin.swift
+++ b/ios/LineLogin.swift
@@ -68,6 +68,21 @@ import LineSDK
     }
   }
 
+  @objc func configure(_ arguments: NSDictionary?, resolver resolve: @escaping RCTPromiseResolveBlock,
+                                          rejecter reject: @escaping RCTPromiseRejectBlock) {
+    guard let args = arguments else {
+      LineLogin.nilArgument(reject)
+      return
+    }
+    guard let channelID = args["channelId"] as? String else { return }
+    Swift.print("[LineSDK] configure \(channelID)")
+    let universalLinkURL = args["universalLinkUrl"] as? URL
+
+    DispatchQueue.main.async {
+      LoginManager.shared.setup(channelID: channelID, universalLinkURL: universalLinkURL)
+    }
+  }
+
   @objc func logout(_ resolve: @escaping RCTPromiseResolveBlock,
                     rejecter reject: @escaping RCTPromiseRejectBlock) {
     LoginManager.shared.logout { result in

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,15 @@ import {
   logout as LineSDKLogout,
   refreshToken as LineSDKRefreshToken,
   verifyAccessToken as LineSDKVerifyAccessToken,
+  configure as LineSDKConfigure,
 } from './lineSDKWrapper'
-import { LoginArguments } from './types'
 
-export {
+import {
+  LoginArguments,
+  ConfigureArguments,
   BotFriendshipStatus,
   AccessToken,
   AccessTokenVerifyResult,
-  LoginArguments,
   LoginPermission,
   LoginResult,
   BotPrompt,
@@ -41,5 +42,8 @@ export default {
   },
   verifyAccessToken() {
     return LineSDKVerifyAccessToken()
+  },
+  configure(args: ConfigureArguments) {
+    return LineSDKConfigure(args)
   },
 }

--- a/src/lineSDKWrapper.ts
+++ b/src/lineSDKWrapper.ts
@@ -14,6 +14,7 @@ import {
   LoginArguments,
   LoginResult,
   UserProfile,
+  ConfigureArguments,
 } from './types'
 
 const { LineLogin } = NativeModules
@@ -58,4 +59,8 @@ export const verifyAccessToken = async (): Promise<AccessTokenVerifyResult> => {
   const result = await LineLogin.verifyAccessToken()
   const deserializedResult = deserializeVerifyAccessToken(result)
   return deserializedResult
+}
+
+export const configure = (args: ConfigureArguments) => {
+  return LineLogin.configure(args)
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,11 @@ export interface AccessToken {
   id_token?: String
 }
 
+export interface ConfigureArguments {
+  channelId: string
+  universalLinkUrl?: string
+}
+
 export interface BotFriendshipStatus {
   friendFlag: boolean
 }


### PR DESCRIPTION
## PR Title

#### 🔄 Type of change:

- [x] ✨Feature/chore
- [ ] :recycle: Refactor
- [ ] :wrench: Bugfixes

---

#### :pencil2: Description:

When using `@xmartlabs/react-native-line` on my project, my client requires that there are separate LINE channels for their separate corporations. So after some time digging in the source code, I found a way to use dynamic channel ID by export the `LoginManager.setup` method to React Native. I thought that this might be a good feature for the SDK so I created this PR. The coding might be not perfect since this is the first time I try to code on Kotlin and Swift, so recommendations are very appreciated!

---

#### :movie_camera: Screen record:

Add a screen record of the execution of your functionality. This way the reviewer can better understand what has been added.

---

#### :pushpin: Notes:

- Need a code review for the convention I used

---

#### :heavy_check_mark:Tasks:

---

#### :warning: Warnings:

- If the `login` method gets called before the `configure` method, the app will crash

---
