### PR TITLE
[Chore] Bump up the Line SDK version to 5.11.0

### DIFF
--- a/RNLine.podspec
+++ b/RNLine.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
     'SWIFT_COMPILATION_MODE' => 'wholemodule'
   }
 
-  s.dependency 'LineSDKSwift', '~> 5.8.1'
+  s.dependency 'LineSDKSwift', '~> 5.11.0'
   s.dependency 'React-Core'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ android {
 
 dependencies {
     implementation "com.facebook.react:react-native:+"
-    implementation "com.linecorp.linesdk:linesdk:5.8.1"
+    implementation "com.linecorp.linesdk:linesdk:5.11.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 }


### PR DESCRIPTION
## PR Title

#### 🔄 Type of change:

- [x] ✨Feature/chore
- [ ] :recycle: Refactor
- [ ] :wrench: Bugfixes

---

#### :pencil2: Description:

Bump up the Line SDK version from `5.8.1` to `5.11.0`.