### PR TITLE
Setting guidelines for repository contributors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+## How to contribute to react-native-line
+
+#### **Did you find a bug?**
+
+* **Ensure the bug was not already reported** by searching on GitHub under [Issues](https://github.com/xmartlabs/react-native-line/issues).
+
+* If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/xmartlabs/react-native-line/issues/new/choose). Be sure to select the proper issue template. Also, include as much relevant information as possible, in particular, add a **code sample** or an **executable test case** demonstrating the expected behavior that is not occurring.
+
+#### **Did you write a patch that fixes a bug?**
+
+* Open a new GitHub pull request with the patch.
+
+* Ensure the PR description clearly describes the problem and solution. Include the relevant issue number if applicable.
+
+#### **Do you intend to add a new feature or change an existing one?**
+
+* Please open an issue using the [feature request template](https://github.com/xmartlabs/react-native-line/issues/new?template=---feature-request.md).
+
+* Be sure to add a clear description of the feature request.
+
+Thanks! :heart: :heart: :heart:
+
+Xmartlabs Team


### PR DESCRIPTION
## PR Title

Setting guidelines for repository contributors

---

#### :pencil2: Description:

Add the `CONTRIBUTING` file to guide the contributors and to accomplish the community standards.

---