### PR TITLE
[Feat] Add setup completion tracking to prevent multiple setup calls

### DIFF
--- a/ios/LineLoginModule.swift
+++ b/ios/LineLoginModule.swift
@@ -23,7 +23,7 @@ import LineSDK
                    rejecter reject: @escaping RCTPromiseRejectBlock) {
 
     if LoginManager.shared.isSetupFinished {
-        resolve(nil)
+        reject("SETUP_ALREADY_COMPLETED", "Setup has already been completed", nil)
         return
     }
 

--- a/ios/LineLoginModule.swift
+++ b/ios/LineLoginModule.swift
@@ -2,6 +2,7 @@ import Foundation
 import LineSDK
 
 @objc(LineLogin) public class LineLogin: NSObject {
+
   @objc public static func application(
     _ application: UIApplication,
     open url: URL,
@@ -20,7 +21,12 @@ import LineSDK
   
   @objc func setup(_ arguments: NSDictionary, resolver resolve: @escaping RCTPromiseResolveBlock,
                    rejecter reject: @escaping RCTPromiseRejectBlock) {
-    
+
+    if LoginManager.shared.isSetupFinished {
+        resolve(nil)
+        return
+    }
+
     guard let channelID = arguments["channelId"] as? String else {
       reject("INVALID_ARGUMENTS", "Missing required argument: channelId", nil)
       return


### PR DESCRIPTION
## PR Title

#### �� Type of change:

- [ ] ✨Feature/chore
- [ ] :recycle: Refactor
- [x] :wrench: Bugfixes

---

#### :pencil2: Description:

This PR added setup completion tracking to prevent multiple calls to the LINE SDK setup function. Fixes #186

**Problem:** The LINE SDK setup function could be called multiple times, causing app crashes or unexpected behavior due to internal SDK errors that developers couldn't properly handle.

**Solution:** Modified the setup method to check the existing `LoginManager.shared.isSetupFinished` property and reject with a clear error message when setup is already completed. This allows developers to handle the situation properly in the JavaScript layer instead of experiencing app crashes.

**Key Changes:**
- Added early return with `reject("SETUP_ALREADY_COMPLETED", "Setup has already been completed", nil)` when setup is already finished

**Acceptance criteria:**
- [x] Setup method rejects with clear error when already completed
- [x] JavaScript layer can properly handle the error
- [x] App crashes prevented when setup is called multiple times
- [x] Existing functionality remains unchanged for first-time setup calls

---

#### :movie_camera: Screen record:

N/A - This is a backend fix that doesn't require UI changes.

---

#### :pushpin: Notes:

- This change only affects the iOS implementation
- Uses existing LINE SDK property `isSetupFinished` instead of adding new variables
- No environment variables or configuration changes required
- Breaking change: Apps that don't handle the new error will need to add error handling

---

#### :heavy_check_mark:Tasks:

- [x] Modify setup method to check `LoginManager.shared.isSetupFinished`
- [x] Implement reject logic instead of resolve for already completed setup
- [x] Ensure proper error handling in JavaScript layer
- [x] Test setup flow to verify error handling works correctly

---

#### :warning: Warnings:

- **Breaking Change**: Apps that don't handle the `SETUP_ALREADY_COMPLETED` error will need to add try-catch blocks
- This fix is specific to iOS implementation only
- Android implementation may need similar changes if the same issue exists
- Relies on LINE SDK's internal setup tracking mechanism
- Developers should handle the error gracefully in their setup calls