### PR TITLE
Bump LineSDKSwift to ~> 5.16.1 for Xcode 26 / Swift 6 support

### DIFF
--- a/react-native-line.podspec
+++ b/react-native-line.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files  = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'LineSDKSwift', '~> 5.14.0'
+  s.dependency 'LineSDKSwith', '~> 5.16.0'
 
   install_modules_dependencies(s)
 end

--- a/react-native-line.podspec
+++ b/react-native-line.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.source_files  = "ios/**/*.{h,m,mm,swift}"
 
-  s.dependency 'LineSDKSwith', '~> 5.16.0'
+  s.dependency 'LineSDKSwift', '~> 5.16.1'
 
   install_modules_dependencies(s)
 end


### PR DESCRIPTION
## Bump LineSDKSwift to `~> 5.16.1` for Xcode 26 / Swift 6 support

#### 🔄 Type of change:

- [ ] ✨Feature/chore
- [ ] :recycle: Refactor
- [x] :wrench: Bugfixes

---

#### :pencil2: Description:

Building this library with Xcode 26 fails because the pinned `LineSDKSwift ~> 5.14.0` is not compatible with Swift 6 strict concurrency, which is the default language mode in Xcode 26.

Errors are emitted from `LineSDKUI/SharingUI/TargetSelecting/ShareTargetSelectingViewController.swift`:

```
sending 'self' risks causing data races
```

(3 occurrences in the same file)

LINE has already addressed this on the SDK side: `LineSDKSwift 5.16.1` (released 2026-04-03) ships with the Swift 6 concurrency fixes. Bumping the podspec dependency from `~> 5.14.0` to `~> 5.16.1` unblocks Xcode 26 builds without any source-level changes here.

---

#### :movie_camera: Screen record:

N/A — single-line dependency bump. Verified locally that the build succeeds.

---

#### :pushpin: Notes:

- LineSDKSwift 5.15 / 5.16 are minor releases over 5.14 with no breaking API changes affecting this wrapper.
- Tested with Expo SDK 54 + Xcode 26.5 + iOS 26.5 Simulator. LINE login flow (including ID token retrieval via `Scope.OpenId`) works as expected.

---

#### :heavy_check_mark:Tasks:

- Bump `s.dependency 'LineSDKSwift', '~> 5.14.0'` to `'~> 5.16.1'` in `react-native-line.podspec`.

---

#### :warning: Warnings:

- Consumers using a pinned `Podfile.lock` will need to run `pod update LineSDKSwift` once after upgrading to pick up the new version.

---